### PR TITLE
Utilize DLL plugin and HardSourceWebpackPlugin to cache node_modules …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ data/users.csv
 resources
 reference
 old-db-models
+public/build/library
+yarn.lock

--- a/library.webpack.config.js
+++ b/library.webpack.config.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+  context: process.cwd(),
+  resolve: {
+    extensions: ['.js', '.jsx', '.json', '.less', '.css'],
+    modules: [__dirname, 'node_modules']
+  },
+  entry: {
+    library: [
+      'react',
+      'react-accessible-accordion',
+      'react-async-poll',
+      'react-autobind',
+      'react-avatar',
+      'react-dom',
+      'react-dropzone',
+      'react-ga',
+      'react-joyride',
+      'react-loadable',
+      'react-markdown',
+      'react-markmirror',
+      'react-mde',
+      'react-modal',
+      'react-paginate',
+      'react-pundit',
+      'react-redux',
+      'react-router',
+      'react-scroll',
+      'react-select',
+      'react-table',
+      'react-tooltip',
+      'redux',
+      'jquery',
+      'axios',
+      'bootstrap',
+      'downloadjs',
+      'draft-js',
+      'loadable-components',
+      'lodash',
+      'moment',
+      'uport',
+      'uport-connect'
+    ]
+  },
+  output: {
+    filename: 'library.dll.js',
+    path: path.resolve(__dirname, './public/build/library'),
+    library: 'library'
+  },
+  plugins: [
+    new webpack.DllPlugin({
+      name: 'library',
+      path: './public/build/library/library.json'
+    })
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@babel/register": "7.0.0-beta.40",
     "axios-mock-adapter": "^1.9.0",
     "babel-eslint": "^8.0.1",
-    "babel-loader": "^8.0.0-beta.2",
+    "babel-loader": "8.0.0-beta.2",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "chai": "^3.5.0",
     "css-loader": "^0.26.1",
@@ -128,6 +128,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-react": "^7.4.0",
     "file-loader": "^0.11.2",
+    "hard-source-webpack-plugin": "https://github.com/talkable/hard-source-webpack-plugin#build",
     "husky": "^0.14.3",
     "image-webpack-loader": "^4.2.0",
     "jsdoc": "^3.5.5",
@@ -144,7 +145,7 @@
     "url-loader": "^1.0.1",
     "webpack": "^4.0.1",
     "webpack-bundle-analyzer": "^2.11.1",
-    "webpack-cli": "^2.0.9",
+    "webpack-cli": "^3.1.0",
     "webpack-livereload-plugin": "^2.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" integrity="sha384-+d0P83n9kaQMCwj8F4RJB66tzIwOKmrdb46+porD/OvrJ+37WqIM7UoBtwHO6Nlg" crossorigin="anonymous">
 
-
+  <script defer src='/build/library/library.dll.js'></script>
   <script defer src="/bundle.js"></script>
 </head>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 var webpack = require("webpack");
 var path = require("path");
 const LiveReloadPlugin = require("webpack-livereload-plugin");
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const isDev = process.env.NODE_ENV === "development";
 const secrets = require("./secrets");
 require("image-webpack-loader");
@@ -74,6 +75,11 @@ module.exports = {
               process.env.UPORT_CLIENT_ADDRESS
             )
           }
+        }),
+        new HardSourceWebpackPlugin(),
+        new webpack.DllReferencePlugin({
+          context: __dirname,
+          manifest: require('./public/build/library/library.json')
         })
       ]
     : [


### PR DESCRIPTION
### Guidelines

This is a pull request to improve Webpack's bundling time. My hypothesis was that it was re-bundling the node_modules after every save.

After some research, I found that a lot of developers were using the `DLL` plugin combined with `HardSourceWebpackPlugin` in order to solve this issue.
https://github.com/mzgoddard/hard-source-webpack-plugin
https://webpack.js.org/plugins/dll-plugin/

The `DLL` plugin allows you to use the result of a one webpack compilation in another. In this PR, I'm using it in order to compile the node_modules first, so it won't have to do that again when running `npm run start-dev`.

Then, the `HardSourceWebpackPlugin` improves the current webpack cacheing methods.

It is my understanding that this will be built into Webpack 5, so it might be unnecessary in the future.

The combination of these cuts down the initial build time from about 70 seconds to 35 seconds. Subsequent builds (i.e. after saving updates) take less than 15 seconds.

---

Run `webpack --config library.webpack.config.js` before `npm run start-dev`
